### PR TITLE
Fix for openevse replying with NK for various commands.

### DIFF
--- a/ocpp/ocpp.py
+++ b/ocpp/ocpp.py
@@ -247,7 +247,7 @@ def main():
         client_cmd = client_call.ClientCall(conf)
         registry = request_registry.RequestRegistry()
         
-        if "yes" in SSL.casefold():
+        if "yes" in SSL.lower():
             websocket.enableTrace(True)
             ws = websocket.WebSocketApp("wss://" + SIP + "/steve/websocket/CentralSystemService/" + uuid,
                                         on_message=on_message,

--- a/openevse/emulator_serial.py
+++ b/openevse/emulator_serial.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python3
+#!/usr/bin/env python
 """
  **** RAPI protocol ****
 Fx - function
@@ -160,6 +160,7 @@ import pathlib
 import sys
 import _thread
 import logging
+import random
 
 logging.getLogger().setLevel(logging.DEBUG)
 
@@ -297,7 +298,8 @@ class Serial:
             print("Length of command is " + str(len(rv)))
         
         print(p1, p2)
-        
+        if random.random() > 0.5:
+            return self.encode("$NK 0 0") 
         if request_for == '$FF':
             response = "$OK 20"
         elif request_for == '$FB':

--- a/openevse/openevse.py
+++ b/openevse/openevse.py
@@ -807,11 +807,15 @@ if SERIAL:
                     return False, []
             else:
                 response = self._read_line()
-                print ("809 response", response)
+                print ("810 response", response)
                 response_match = self.respose_regex.match(response)
-                print("810 response_match", response_match)
+                print("812 response_match", response_match)
                 if response_match is not None:
-                    return response_match.group('status') == 'OK', (response_match.group('args') or '').split()
+                    if response_match.group('status') == 'OK':
+                        return True, (response_match.group('args') or '').split()
+                    else:
+                        print("FATL: 817 reponse is NK");
+                        return response_match.group('status') == 'NK', (response_match.group('args') or '').split()
                 else:
                     if response[:3] == '$ST':
                         new_status = states[int(response.split()[1], 16)]

--- a/system.properties
+++ b/system.properties
@@ -1,3 +1,3 @@
 capability=OPENEVSE_EMULATOR
 ocpp_server=sip.ibeyonde.com:888
-ssl_enabled=yes
+ssl_enabled=no


### PR DESCRIPTION
Added a random reply of "$NK 0 0" from the emulator to simulate errors

@kernelkraut i have added $NK handling on openevse.py. Also modified the emulator to return $NK for about 50% of the commands.
